### PR TITLE
Mark the plugin as an Incubated one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
-Pipeline As Yaml Plugin
+Pipeline As Yaml Plugin for Jenkins (Incubated)
 =======================
+
 This plugin enables defining Jenkins Pipelines in YAML Format. 
+
+:exclamation: **Incubation Stage**: Currently this plugin is in the incubation stage.
+It will evolve further to become more aligned with the Pipeline ecosystem, and some breaking changes are plausible.
+You are welcome to try out this plugin and to provide your feedback.
+Contributions are welcome!
 
 # Description
 Jenkins enables defining pipelines with specific DSL. With this plugin Jenkins pipelines can be defined in Yaml format.

--- a/pom.xml
+++ b/pom.xml
@@ -9,11 +9,10 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>pipeline-as-yaml</artifactId>
-    <version>0.1.2-SNAPSHOT</version>
+    <version>0.2.0-rc-SNAPSHOT</version>
     <packaging>hpi</packaging>
-    <name>Pipeline As Yaml</name>
-    <description>Enables defining Jenkins Pipelines in Yaml Format
-    </description>
+    <name>Pipeline As YAML (Incubated)</name>
+    <description>Enables defining Jenkins Pipelines in YAML Format</description>
     <url>https://github.com/jenkinsci/pipeline-as-yaml-plugin</url>
     <licenses>
         <license>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -2,7 +2,7 @@
 <!--
 The MIT License
 
-Copyright 2015 CloudBees, Inc.
+Copyright 2020 Aytunc Beken and other Jenkins contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -24,5 +24,6 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <div>
-  Enables defining Jenkins Pipelines as Yaml Files.
+  Enables defining Jenkins Pipelines as YAML Files.
+  This plugin is currently in the Incubation Stage (see the documentation).
 </div>


### PR DESCRIPTION
Hi @aytuncbeken . IMHo releasing this plugin as a GA version was a bit premature. It would be great to discuss it among Jenkins developers and Pipeline Authoring SIG so that we could review it together and ensure it fits well into the existing plugin ecosystem. This feature is IMO critical to the Jenkins project, and I would be happy to help it to  become a part of the default Pipeline ecosystem in the future. But there might be some breaking changes required to make it happen.

I would suggest moving the plugin into the incubation stage and adding `rc` to the release versions. It would keep the plugin in the main update center, but it would highlight the fact that it is a subject to changes.

We could also exclude it from the update center, but it is IMHO less desirable in the current state.

CC @markyjackson-taulia @bitwiseman 