### PR TITLE
Use Snakeyaml Plugin as a source of Snakeyaml lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,9 +129,8 @@
             <version>1.18.12</version>
         </dependency>
         <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>1.26</version>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>snakeyaml-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
It slightly reduces the plugin size and delegates the Snakeyaml version management to the bill of materials