### PR TITLE
Remove dependency on Matrix Project plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,11 +52,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>matrix-project</artifactId>
-            <version>1.14</version>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
         </dependency>


### PR DESCRIPTION
Apparently  the dependency is not used in the plugin's codebase or tests.
