### PR TITLE
Properly propagate root cause of exception in PipelineParser

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/yaml/pipeline/exceptions/PipelineAsYamlRuntimeException.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/yaml/pipeline/exceptions/PipelineAsYamlRuntimeException.java
@@ -16,4 +16,9 @@ public class PipelineAsYamlRuntimeException extends RuntimeException {
         super(s);
         LOGGER.log(Level.FINE, s, this);
     }
+
+    public PipelineAsYamlRuntimeException(String message, Throwable cause) {
+        super(message, cause);
+        LOGGER.log(Level.FINE, s, this);
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/yaml/pipeline/exceptions/PipelineAsYamlRuntimeException.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/yaml/pipeline/exceptions/PipelineAsYamlRuntimeException.java
@@ -19,6 +19,6 @@ public class PipelineAsYamlRuntimeException extends RuntimeException {
 
     public PipelineAsYamlRuntimeException(String message, Throwable cause) {
         super(message, cause);
-        LOGGER.log(Level.FINE, s, this);
+        LOGGER.log(Level.FINE, message, this);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/yaml/pipeline/parsers/PipelineParser.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/yaml/pipeline/parsers/PipelineParser.java
@@ -50,7 +50,7 @@ public class PipelineParser extends AbstractParser implements ParserInterface<Pi
             return Optional.empty();
         }
         catch (Exception e) {
-            throw new PipelineAsYamlRuntimeException(e.getLocalizedMessage());
+            throw new PipelineAsYamlRuntimeException(e.getLocalizedMessage(), e);
         }
     }
 


### PR DESCRIPTION
Fixes #24 . I suspect that `PipelineAsYamlRuntimeException` may also need an update later