### PR TITLE
Migrate tests to JUnit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <licenses>
     <license>
       <name>MIT License</name>
-      <url>http://opensource.org/licenses/MIT</url>
+      <url>https://opensource.org/licenses/MIT</url>
     </license>
   </licenses>
   <scm>

--- a/src/test/java/io/jenkins/plugins/pipeline/AgentParserTest.java
+++ b/src/test/java/io/jenkins/plugins/pipeline/AgentParserTest.java
@@ -1,5 +1,8 @@
 package io.jenkins.plugins.pipeline;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import io.jenkins.plugins.pipeline.models.AgentModel;
 import io.jenkins.plugins.pipeline.models.PipelineModel;
 import io.jenkins.plugins.pipeline.parsers.PipelineParser;
@@ -8,139 +11,136 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class AgentParserTest {
-
-    @Before
-    public void setup() {}
+class AgentParserTest {
 
     @Test
-    public void agentAnyTest() throws IOException {
+    void agentAnyTest() throws IOException {
         String jenkinsFileContent =
                 FileUtils.readFileToString(new File("src/test/resources/agent/agentAny.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<AgentModel> agentModel = pipelineModel.get().getAgent();
-        Assert.assertTrue(agentModel.isPresent());
-        Assert.assertEquals(agentModel.get().getAgentType(), "any");
+        assertTrue(agentModel.isPresent());
+        assertEquals("any", agentModel.get().getAgentType());
     }
 
     @Test
-    public void agentAnyShortTest() throws IOException {
+    void agentAnyShortTest() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/agent/agentAnyShort.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<AgentModel> agentModel = pipelineModel.get().getAgent();
-        Assert.assertTrue(agentModel.isPresent());
-        Assert.assertEquals(agentModel.get().getAgentType(), "any");
+        assertTrue(agentModel.isPresent());
+        assertEquals("any", agentModel.get().getAgentType());
     }
 
     @Test
-    public void agentNoneTest() throws IOException {
+    void agentNoneTest() throws IOException {
         String jenkinsFileContent =
                 FileUtils.readFileToString(new File("src/test/resources/agent/agentNone.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<AgentModel> agentModel = pipelineModel.get().getAgent();
-        Assert.assertTrue(agentModel.isPresent());
-        Assert.assertEquals(agentModel.get().getAgentType(), "none");
+        assertTrue(agentModel.isPresent());
+        assertEquals("none", agentModel.get().getAgentType());
     }
 
     @Test
-    public void agentLabel() throws IOException {
+    void agentLabel() throws IOException {
         String jenkinsFileContent =
                 FileUtils.readFileToString(new File("src/test/resources/agent/agentLabel.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<AgentModel> agentModel = pipelineModel.get().getAgent();
-        Assert.assertTrue(agentModel.isPresent());
-        Assert.assertEquals(agentModel.get().getAgentType(), "node");
-        Assert.assertEquals(1, agentModel.get().getAgentParameter().size());
-        Assert.assertEquals(agentModel.get().getAgentParameter().get(0).getKey(), "label");
-        Assert.assertEquals(agentModel.get().getAgentParameter().get(0).getValue(), "label");
+        assertTrue(agentModel.isPresent());
+        assertEquals("node", agentModel.get().getAgentType());
+        assertEquals(1, agentModel.get().getAgentParameter().size());
+        assertEquals("label", agentModel.get().getAgentParameter().get(0).getKey());
+        assertEquals("label", agentModel.get().getAgentParameter().get(0).getValue());
     }
 
     @Test
-    public void agentNode() throws IOException {
+    void agentNode() throws IOException {
         String jenkinsFileContent =
                 FileUtils.readFileToString(new File("src/test/resources/agent/agentNode.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<AgentModel> agentModel = pipelineModel.get().getAgent();
-        Assert.assertTrue(agentModel.isPresent());
-        Assert.assertEquals(agentModel.get().getAgentType(), "node");
-        Assert.assertEquals(1, agentModel.get().getAgentParameter().size());
-        Assert.assertEquals(agentModel.get().getAgentParameter().get(0).getKey(), "label");
-        Assert.assertEquals(agentModel.get().getAgentParameter().get(0).getValue(), "label");
+        assertTrue(agentModel.isPresent());
+        assertEquals("node", agentModel.get().getAgentType());
+        assertEquals(1, agentModel.get().getAgentParameter().size());
+        assertEquals("label", agentModel.get().getAgentParameter().get(0).getKey());
+        assertEquals("label", agentModel.get().getAgentParameter().get(0).getValue());
     }
 
     @Test
-    public void agentDocker() throws IOException {
+    void agentDocker() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/agent/agentDocker.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<AgentModel> agentModel = pipelineModel.get().getAgent();
-        Assert.assertTrue(agentModel.isPresent());
-        Assert.assertEquals(agentModel.get().getAgentType(), "docker");
-        Assert.assertEquals(5, agentModel.get().getAgentParameter().size());
+        assertTrue(agentModel.isPresent());
+        assertEquals("docker", agentModel.get().getAgentType());
+        assertEquals(5, agentModel.get().getAgentParameter().size());
     }
 
     @Test
-    public void agentDockerFile() throws IOException {
+    void agentDockerFile() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/agent/agentDockerfile.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<AgentModel> agentModel = pipelineModel.get().getAgent();
-        Assert.assertTrue(agentModel.isPresent());
-        Assert.assertEquals(agentModel.get().getAgentType(), "dockerfile");
-        Assert.assertEquals(5, agentModel.get().getAgentParameter().size());
+        assertTrue(agentModel.isPresent());
+        assertEquals("dockerfile", agentModel.get().getAgentType());
+        assertEquals(5, agentModel.get().getAgentParameter().size());
     }
 
     @Test
-    public void agentKubernetes() throws IOException {
+    void agentKubernetes() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/agent/agentKubernetes.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<AgentModel> agentModel = pipelineModel.get().getAgent();
-        Assert.assertTrue(agentModel.isPresent());
-        Assert.assertEquals("kubernetes", agentModel.get().getAgentType());
-        Assert.assertEquals(1, agentModel.get().getAgentParameter().size());
-        Assert.assertEquals("yaml", agentModel.get().getAgentParameter().get(0).getKey());
-        Assert.assertEquals(
-                "pipeline {\n"
-                        + "  agent {\n"
-                        + "    kubernetes {\n"
-                        + "      yaml \"\"\"\n"
-                        + "      apiVersion: v1\n"
-                        + "      kind: Pod\n"
-                        + "      spec:\n"
-                        + "        imagePullSecrets:\n"
-                        + "        - name: my-creds\n"
-                        + "        containers:\n"
-                        + "        - name: ubuntu\n"
-                        + "          image: myimage:1.1\n"
-                        + "          command: ['sleep', 'infinity']\n"
-                        + "          tty: true\n"
-                        + "          imagePullPolicy: Always\n"
-                        + "      \"\"\"\n"
-                        + "    }\n"
-                        + "  }\n"
-                        + "}\n",
+        assertTrue(agentModel.isPresent());
+        assertEquals("kubernetes", agentModel.get().getAgentType());
+        assertEquals(1, agentModel.get().getAgentParameter().size());
+        assertEquals("yaml", agentModel.get().getAgentParameter().get(0).getKey());
+        assertEquals(
+                """
+                        pipeline {
+                          agent {
+                            kubernetes {
+                              yaml ""\"
+                              apiVersion: v1
+                              kind: Pod
+                              spec:
+                                imagePullSecrets:
+                                - name: my-creds
+                                containers:
+                                - name: ubuntu
+                                  image: myimage:1.1
+                                  command: ['sleep', 'infinity']
+                                  tty: true
+                                  imagePullPolicy: Always
+                              ""\"
+                            }
+                          }
+                        }
+                        """,
                 pipelineModel.get().toPrettyGroovy());
     }
 }

--- a/src/test/java/io/jenkins/plugins/pipeline/EnvironmentParserTest.java
+++ b/src/test/java/io/jenkins/plugins/pipeline/EnvironmentParserTest.java
@@ -1,5 +1,9 @@
 package io.jenkins.plugins.pipeline;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import io.jenkins.plugins.pipeline.models.EnvironmentModel;
 import io.jenkins.plugins.pipeline.models.EnvironmentVariableModel;
 import io.jenkins.plugins.pipeline.models.PipelineModel;
@@ -9,49 +13,42 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class EnvironmentParserTest {
-
-    @Rule
-    public JenkinsRule jenkins = new JenkinsRule();
-
-    @Before
-    public void setup() {}
+@WithJenkins
+class EnvironmentParserTest {
 
     @Test
-    public void environmentSingle() throws IOException {
+    void environmentSingle(JenkinsRule jenkins) throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/environment/environmentSingle.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<EnvironmentModel> environmentModel = pipelineModel.get().getEnvironment();
-        Assert.assertTrue(environmentModel.isPresent());
-        Assert.assertEquals(1, environmentModel.get().getEnvironmentVariables().size());
+        assertTrue(environmentModel.isPresent());
+        assertEquals(1, environmentModel.get().getEnvironmentVariables().size());
         for (EnvironmentVariableModel variableModel : environmentModel.get().getEnvironmentVariables()) {
-            Assert.assertEquals("KEY1", variableModel.getKey());
-            Assert.assertEquals("VAL1", variableModel.getValue());
+            assertEquals("KEY1", variableModel.getKey());
+            assertEquals("VAL1", variableModel.getValue());
         }
     }
 
     @Test
-    public void environmentMulti() throws IOException {
+    void environmentMulti(JenkinsRule jenkins) throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/environment/environmentMulti.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<EnvironmentModel> environmentModel = pipelineModel.get().getEnvironment();
-        Assert.assertTrue(environmentModel.isPresent());
-        Assert.assertEquals(2, environmentModel.get().getEnvironmentVariables().size());
+        assertTrue(environmentModel.isPresent());
+        assertEquals(2, environmentModel.get().getEnvironmentVariables().size());
         for (EnvironmentVariableModel variableModel : environmentModel.get().getEnvironmentVariables()) {
-            Assert.assertNotNull(variableModel.getKey());
-            Assert.assertNotNull(variableModel.getValue());
+            assertNotNull(variableModel.getKey());
+            assertNotNull(variableModel.getValue());
         }
     }
 }

--- a/src/test/java/io/jenkins/plugins/pipeline/LibraryParserTest.java
+++ b/src/test/java/io/jenkins/plugins/pipeline/LibraryParserTest.java
@@ -1,5 +1,8 @@
 package io.jenkins.plugins.pipeline;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import io.jenkins.plugins.pipeline.models.LibraryModel;
 import io.jenkins.plugins.pipeline.models.PipelineModel;
 import io.jenkins.plugins.pipeline.parsers.PipelineParser;
@@ -8,37 +11,36 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class LibraryParserTest {
+class LibraryParserTest {
 
     @Test
-    public void scenario1() throws IOException {
+    void scenario1() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/library/librarySingle.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<LibraryModel> library = pipelineModel.get().getLibrary();
-        Assert.assertTrue(library.isPresent());
-        Assert.assertEquals(1, library.get().getLibraryList().size());
-        Assert.assertEquals("'library@master'", library.get().getLibraryList().get(0));
+        assertTrue(library.isPresent());
+        assertEquals(1, library.get().getLibraryList().size());
+        assertEquals("'library@master'", library.get().getLibraryList().get(0));
         System.out.println(pipelineModel.get().toPrettyGroovy());
     }
 
     @Test
-    public void scenario2() throws IOException {
+    void scenario2() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/library/libraryMulti.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<LibraryModel> library = pipelineModel.get().getLibrary();
-        Assert.assertTrue(library.isPresent());
-        Assert.assertEquals(2, library.get().getLibraryList().size());
-        Assert.assertEquals("'library@master'", library.get().getLibraryList().get(0));
-        Assert.assertEquals("'library@branch'", library.get().getLibraryList().get(1));
+        assertTrue(library.isPresent());
+        assertEquals(2, library.get().getLibraryList().size());
+        assertEquals("'library@master'", library.get().getLibraryList().get(0));
+        assertEquals("'library@branch'", library.get().getLibraryList().get(1));
         System.out.println(pipelineModel.get().toPrettyGroovy());
     }
 }

--- a/src/test/java/io/jenkins/plugins/pipeline/OptionsParserTest.java
+++ b/src/test/java/io/jenkins/plugins/pipeline/OptionsParserTest.java
@@ -1,5 +1,8 @@
 package io.jenkins.plugins.pipeline;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import io.jenkins.plugins.pipeline.models.OptionsModel;
 import io.jenkins.plugins.pipeline.models.PipelineModel;
 import io.jenkins.plugins.pipeline.parsers.PipelineParser;
@@ -8,36 +11,31 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class OptionsParserTest {
-
-    @Before
-    public void setup() {}
+class OptionsParserTest {
 
     @Test
-    public void optionsSingleTest() throws IOException {
+    void optionsSingleTest() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/options/optionsSingle.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<OptionsModel> optionsModel = pipelineModel.get().getOptions();
-        Assert.assertTrue(optionsModel.isPresent());
-        Assert.assertEquals(1, optionsModel.get().getOptionList().size());
+        assertTrue(optionsModel.isPresent());
+        assertEquals(1, optionsModel.get().getOptionList().size());
     }
 
     @Test
-    public void optionsMultiTest() throws IOException {
+    void optionsMultiTest() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/options/optionsMulti.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<OptionsModel> optionsModel = pipelineModel.get().getOptions();
-        Assert.assertTrue(optionsModel.isPresent());
-        Assert.assertEquals(3, optionsModel.get().getOptionList().size());
+        assertTrue(optionsModel.isPresent());
+        assertEquals(3, optionsModel.get().getOptionList().size());
     }
 }

--- a/src/test/java/io/jenkins/plugins/pipeline/ParallelParserTest.java
+++ b/src/test/java/io/jenkins/plugins/pipeline/ParallelParserTest.java
@@ -1,5 +1,8 @@
 package io.jenkins.plugins.pipeline;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import io.jenkins.plugins.pipeline.models.ParallelModel;
 import io.jenkins.plugins.pipeline.models.PipelineModel;
 import io.jenkins.plugins.pipeline.models.StageModel;
@@ -11,50 +14,45 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ParallelParserTest {
-
-    @Before
-    public void setup() {}
+class ParallelParserTest {
 
     @Test
-    public void parallelScenario1() throws IOException {
+    void parallelScenario1() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/parallel/parallelBasic.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<StagesModel> stages = pipelineModel.get().getStages();
-        Assert.assertTrue(stages.isPresent());
+        assertTrue(stages.isPresent());
         List<StageModel> stageModelList = stages.get().getStageModelList();
-        Assert.assertEquals(2, stageModelList.size());
+        assertEquals(2, stageModelList.size());
         StageModel stageModel = stageModelList.get(1);
         Optional<ParallelModel> parallelModel = stageModel.getParallelModel();
-        Assert.assertTrue(parallelModel.isPresent());
+        assertTrue(parallelModel.isPresent());
         List<StageModel> parallelStageModels = parallelModel.get().getStageModelList();
-        Assert.assertEquals(2, parallelStageModels.size());
+        assertEquals(2, parallelStageModels.size());
     }
 
     @Test
-    public void parallelScenario2() throws IOException {
+    void parallelScenario2() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/parallel/parallelFailfast.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<StagesModel> stages = pipelineModel.get().getStages();
-        Assert.assertTrue(stages.isPresent());
+        assertTrue(stages.isPresent());
         List<StageModel> stageModelList = stages.get().getStageModelList();
-        Assert.assertEquals(2, stageModelList.size());
+        assertEquals(2, stageModelList.size());
         StageModel stageModel = stageModelList.get(1);
-        Assert.assertTrue(stageModel.getFailFast().isPresent());
-        Assert.assertTrue(stageModel.getFailFast().get());
+        assertTrue(stageModel.getFailFast().isPresent());
+        assertTrue(stageModel.getFailFast().get());
         Optional<ParallelModel> parallelModel = stageModel.getParallelModel();
-        Assert.assertTrue(parallelModel.isPresent());
+        assertTrue(parallelModel.isPresent());
         List<StageModel> parallelStageModels = parallelModel.get().getStageModelList();
-        Assert.assertEquals(2, parallelStageModels.size());
+        assertEquals(2, parallelStageModels.size());
     }
 }

--- a/src/test/java/io/jenkins/plugins/pipeline/ParametersParserTest.java
+++ b/src/test/java/io/jenkins/plugins/pipeline/ParametersParserTest.java
@@ -1,5 +1,8 @@
 package io.jenkins.plugins.pipeline;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import io.jenkins.plugins.pipeline.models.ParametersModel;
 import io.jenkins.plugins.pipeline.models.PipelineModel;
 import io.jenkins.plugins.pipeline.parsers.PipelineParser;
@@ -8,36 +11,31 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ParametersParserTest {
-
-    @Before
-    public void setup() {}
+class ParametersParserTest {
 
     @Test
-    public void parametersSingleTest() throws IOException {
+    void parametersSingleTest() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/parameters/parametersSingle.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<ParametersModel> parametersModel = pipelineModel.get().getParameters();
-        Assert.assertTrue(parametersModel.isPresent());
-        Assert.assertEquals(1, parametersModel.get().getParametersList().size());
+        assertTrue(parametersModel.isPresent());
+        assertEquals(1, parametersModel.get().getParametersList().size());
     }
 
     @Test
-    public void parametersMultiTest() throws IOException {
+    void parametersMultiTest() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/parameters/parametersMulti.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<ParametersModel> parametersModel = pipelineModel.get().getParameters();
-        Assert.assertTrue(parametersModel.isPresent());
-        Assert.assertEquals(2, parametersModel.get().getParametersList().size());
+        assertTrue(parametersModel.isPresent());
+        assertEquals(2, parametersModel.get().getParametersList().size());
     }
 }

--- a/src/test/java/io/jenkins/plugins/pipeline/PipelineAsYamlScmFlowDefinitionTest.java
+++ b/src/test/java/io/jenkins/plugins/pipeline/PipelineAsYamlScmFlowDefinitionTest.java
@@ -3,10 +3,12 @@ package io.jenkins.plugins.pipeline;
 import hudson.plugins.git.GitSCM;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 import jenkins.plugins.git.GitSCMSource;
 import jenkins.plugins.git.GitSampleRepoRule;
+import jenkins.plugins.git.traits.BranchDiscoveryTrait;
+import jenkins.scm.impl.trait.WildcardSCMHeadFilterTrait;
 import org.apache.commons.io.FileUtils;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -60,12 +62,13 @@ public class PipelineAsYamlScmFlowDefinitionTest {
         this.libraryCodeRepo.git("add", "vars/customSteps.groovy");
         this.libraryCodeRepo.git("commit", "--all", "--message=InitRepoWithStep");
 
-        LibraryConfiguration sharedLibraryConfiguration = new LibraryConfiguration(
-                "customSharedLibrary",
-                new SCMSourceRetriever(new GitSCMSource(null, this.libraryCodeRepo.toString(), "", "*", "", false)));
+        GitSCMSource source = new GitSCMSource(this.libraryCodeRepo.toString());
+        source.setTraits(List.of(new BranchDiscoveryTrait(), new WildcardSCMHeadFilterTrait("*", "")));
+        LibraryConfiguration sharedLibraryConfiguration =
+                new LibraryConfiguration("customSharedLibrary", new SCMSourceRetriever(source));
 
         GlobalLibraries globalLibraries = GlobalLibraries.get();
-        globalLibraries.setLibraries(Arrays.asList(sharedLibraryConfiguration));
+        globalLibraries.setLibraries(List.of(sharedLibraryConfiguration));
 
         String yamlJenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/job/pipelineTestWithLibrary.yml"), StandardCharsets.UTF_8);

--- a/src/test/java/io/jenkins/plugins/pipeline/PipelineAsYamlScriptFlowDefinitionTest.java
+++ b/src/test/java/io/jenkins/plugins/pipeline/PipelineAsYamlScriptFlowDefinitionTest.java
@@ -2,10 +2,12 @@ package io.jenkins.plugins.pipeline;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 import jenkins.plugins.git.GitSCMSource;
 import jenkins.plugins.git.GitSampleRepoRule;
+import jenkins.plugins.git.traits.BranchDiscoveryTrait;
+import jenkins.scm.impl.trait.WildcardSCMHeadFilterTrait;
 import org.apache.commons.io.FileUtils;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -54,12 +56,13 @@ public class PipelineAsYamlScriptFlowDefinitionTest {
         this.libraryCodeRepo.git("add", "vars/customSteps.groovy");
         this.libraryCodeRepo.git("commit", "--all", "--message=InitRepoWithStep");
 
-        LibraryConfiguration sharedLibraryConfiguration = new LibraryConfiguration(
-                "customSharedLibrary",
-                new SCMSourceRetriever(new GitSCMSource(null, this.libraryCodeRepo.toString(), "", "*", "", false)));
+        GitSCMSource source = new GitSCMSource(this.libraryCodeRepo.toString());
+        source.setTraits(List.of(new BranchDiscoveryTrait(), new WildcardSCMHeadFilterTrait("*", "")));
+        LibraryConfiguration sharedLibraryConfiguration =
+                new LibraryConfiguration("customSharedLibrary", new SCMSourceRetriever(source));
 
         GlobalLibraries globalLibraries = GlobalLibraries.get();
-        globalLibraries.setLibraries(Arrays.asList(sharedLibraryConfiguration));
+        globalLibraries.setLibraries(List.of(sharedLibraryConfiguration));
 
         String yamlJenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/job/pipelineTestWithLibrary.yml"), StandardCharsets.UTF_8);

--- a/src/test/java/io/jenkins/plugins/pipeline/PipelineSnippetizerTest.java
+++ b/src/test/java/io/jenkins/plugins/pipeline/PipelineSnippetizerTest.java
@@ -1,35 +1,35 @@
 package io.jenkins.plugins.pipeline;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class PipelineSnippetizerTest {
-
-    @Rule
-    public JenkinsRule jenkinsRule = new JenkinsRule();
+@WithJenkins
+class PipelineSnippetizerTest {
 
     @Test
-    public void convertTest() throws IOException {
+    void convertTest(JenkinsRule jenkins) throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/pipeline/pipelineAllinOne.yml"), StandardCharsets.UTF_8);
         PipelineAsYamlSnippetizer pipelineAsYamlSnippetizer = new PipelineAsYamlSnippetizer();
         String pipelineDec = pipelineAsYamlSnippetizer.convertToDec(jenkinsFileContent);
-        Assert.assertNotNull(pipelineDec);
+        assertNotNull(pipelineDec);
     }
 
     @Test
-    public void validateTest() throws IOException {
+    void validateTest(JenkinsRule jenkins) throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/pipeline/pipelineAllinOne.yml"), StandardCharsets.UTF_8);
         PipelineAsYamlSnippetizer pipelineAsYamlSnippetizer = new PipelineAsYamlSnippetizer();
         String validationResponse = pipelineAsYamlSnippetizer.parseAndValidatePay(jenkinsFileContent);
-        Assert.assertEquals("Valid", validationResponse);
+        assertEquals("Valid", validationResponse);
     }
 
     // FIXME Add tests also for web ui

--- a/src/test/java/io/jenkins/plugins/pipeline/PostParserTest.java
+++ b/src/test/java/io/jenkins/plugins/pipeline/PostParserTest.java
@@ -1,5 +1,8 @@
 package io.jenkins.plugins.pipeline;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import io.jenkins.plugins.pipeline.models.*;
 import io.jenkins.plugins.pipeline.parsers.PipelineParser;
 import java.io.File;
@@ -8,80 +11,75 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class PostParserTest {
-
-    @Before
-    public void setup() {}
+class PostParserTest {
 
     @Test
-    public void postSteps() throws IOException {
+    void postSteps() throws IOException {
         String jenkinsFileContent =
                 FileUtils.readFileToString(new File("src/test/resources/post/postSteps.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<PostModel> postModel = pipelineModel.get().getPost();
-        Assert.assertTrue(postModel.isPresent());
-        Assert.assertEquals(10, postModel.get().getChildPostModels().size());
+        assertTrue(postModel.isPresent());
+        assertEquals(10, postModel.get().getChildPostModels().size());
         for (ChildPostModel childPostModel : postModel.get().getChildPostModels()) {
             List<String> postSteps = childPostModel.getPostSteps().get().getSteps();
-            Assert.assertEquals(1, postSteps.size());
+            assertEquals(1, postSteps.size());
         }
     }
 
     @Test
-    public void postScripts() throws IOException {
+    void postScripts() throws IOException {
         String jenkinsFileContent =
                 FileUtils.readFileToString(new File("src/test/resources/post/postScripts.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<PostModel> postModel = pipelineModel.get().getPost();
-        Assert.assertTrue(postModel.isPresent());
-        Assert.assertEquals(10, postModel.get().getChildPostModels().size());
+        assertTrue(postModel.isPresent());
+        assertEquals(10, postModel.get().getChildPostModels().size());
         for (ChildPostModel childPostModel : postModel.get().getChildPostModels()) {
             Optional<ScriptModel> postScript = childPostModel.getPostScript();
-            Assert.assertTrue(postScript.isPresent());
-            Assert.assertEquals(1, postScript.get().getScripts().size());
+            assertTrue(postScript.isPresent());
+            assertEquals(1, postScript.get().getScripts().size());
         }
     }
 
     @Test
-    public void postMultiSteps() throws IOException {
+    void postMultiSteps() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/post/postMultiSteps.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<PostModel> postModel = pipelineModel.get().getPost();
-        Assert.assertTrue(postModel.isPresent());
-        Assert.assertEquals(10, postModel.get().getChildPostModels().size());
+        assertTrue(postModel.isPresent());
+        assertEquals(10, postModel.get().getChildPostModels().size());
         for (ChildPostModel childPostModel : postModel.get().getChildPostModels()) {
             Optional<StepsModel> postSteps = childPostModel.getPostSteps();
-            Assert.assertTrue(postSteps.isPresent());
+            assertTrue(postSteps.isPresent());
             List<String> stepsList = postSteps.get().getSteps();
-            Assert.assertEquals(2, stepsList.size());
+            assertEquals(2, stepsList.size());
         }
     }
 
     @Test
-    public void postMultiScripts() throws IOException {
+    void postMultiScripts() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/post/postMultiScripts.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<PostModel> postModel = pipelineModel.get().getPost();
-        Assert.assertTrue(postModel.isPresent());
-        Assert.assertEquals(10, postModel.get().getChildPostModels().size());
+        assertTrue(postModel.isPresent());
+        assertEquals(10, postModel.get().getChildPostModels().size());
         for (ChildPostModel childPostModel : postModel.get().getChildPostModels()) {
             Optional<ScriptModel> postScript = childPostModel.getPostScript();
-            Assert.assertTrue(postScript.isPresent());
-            Assert.assertEquals(2, postScript.get().getScripts().size());
+            assertTrue(postScript.isPresent());
+            assertEquals(2, postScript.get().getScripts().size());
         }
     }
 }

--- a/src/test/java/io/jenkins/plugins/pipeline/StagesParserTest.java
+++ b/src/test/java/io/jenkins/plugins/pipeline/StagesParserTest.java
@@ -1,5 +1,8 @@
 package io.jenkins.plugins.pipeline;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import io.jenkins.plugins.pipeline.models.*;
 import io.jenkins.plugins.pipeline.parsers.PipelineParser;
 import java.io.File;
@@ -7,142 +10,137 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class StagesParserTest {
-
-    @Before
-    public void setup() {}
+class StagesParserTest {
 
     @Test
-    public void scenario1() throws IOException {
+    void scenario1() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/stages/stageBasic.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<StagesModel> stagesModel = pipelineModel.get().getStages();
-        Assert.assertTrue(stagesModel.isPresent());
-        Assert.assertEquals(1, stagesModel.get().getStageModelList().size());
+        assertTrue(stagesModel.isPresent());
+        assertEquals(1, stagesModel.get().getStageModelList().size());
         StageModel stageModel = stagesModel.get().getStageModelList().get(0);
-        Assert.assertEquals("Stage1", stageModel.getName());
+        assertEquals("Stage1", stageModel.getName());
     }
 
     @Test
-    public void scenario2() throws IOException {
+    void scenario2() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/stages/stagesBasicMulti.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<StagesModel> stagesModel = pipelineModel.get().getStages();
-        Assert.assertTrue(stagesModel.isPresent());
-        Assert.assertEquals(2, stagesModel.get().getStageModelList().size());
+        assertTrue(stagesModel.isPresent());
+        assertEquals(2, stagesModel.get().getStageModelList().size());
     }
 
     @Test
-    public void scenarioAgent() throws IOException {
+    void scenarioAgent() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/stages/stagesScenarioAgent.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<StagesModel> stagesModel = pipelineModel.get().getStages();
-        Assert.assertTrue(stagesModel.isPresent());
-        Assert.assertEquals(1, stagesModel.get().getStageModelList().size());
+        assertTrue(stagesModel.isPresent());
+        assertEquals(1, stagesModel.get().getStageModelList().size());
         StageModel stageModel = stagesModel.get().getStageModelList().get(0);
         Optional<AgentModel> agentModel = stageModel.getAgentModel();
-        Assert.assertTrue(agentModel.isPresent());
-        Assert.assertEquals(agentModel.get().getAgentType(), "none");
+        assertTrue(agentModel.isPresent());
+        assertEquals("none", agentModel.get().getAgentType());
     }
 
     @Test
-    public void scenarioPost() throws IOException {
+    void scenarioPost() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/stages/stagesScenarioPost.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<StagesModel> stagesModel = pipelineModel.get().getStages();
-        Assert.assertTrue(stagesModel.isPresent());
-        Assert.assertEquals(1, stagesModel.get().getStageModelList().size());
+        assertTrue(stagesModel.isPresent());
+        assertEquals(1, stagesModel.get().getStageModelList().size());
         StageModel stageModel = stagesModel.get().getStageModelList().get(0);
         Optional<PostModel> postModel = stageModel.getPostModel();
-        Assert.assertTrue(postModel.isPresent());
-        Assert.assertEquals(1, postModel.get().getChildPostModels().size());
+        assertTrue(postModel.isPresent());
+        assertEquals(1, postModel.get().getChildPostModels().size());
     }
 
     @Test
-    public void scenarioTools() throws IOException {
+    void scenarioTools() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/stages/stagesScenarioTools.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<StagesModel> stagesModel = pipelineModel.get().getStages();
-        Assert.assertTrue(stagesModel.isPresent());
-        Assert.assertEquals(1, stagesModel.get().getStageModelList().size());
+        assertTrue(stagesModel.isPresent());
+        assertEquals(1, stagesModel.get().getStageModelList().size());
         StageModel stageModel = stagesModel.get().getStageModelList().get(0);
         Optional<ToolsModel> toolsModel = stageModel.getToolsModel();
-        Assert.assertTrue(toolsModel.isPresent());
-        Assert.assertEquals(1, toolsModel.get().getChildToolModels().size());
+        assertTrue(toolsModel.isPresent());
+        assertEquals(1, toolsModel.get().getChildToolModels().size());
     }
 
     @Test
-    public void scenarioInnerStages() throws IOException {
+    void scenarioInnerStages() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/stages/stagesScenarioInnerStages.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<StagesModel> stagesModel = pipelineModel.get().getStages();
-        Assert.assertTrue(stagesModel.isPresent());
-        Assert.assertEquals(1, stagesModel.get().getStageModelList().size());
+        assertTrue(stagesModel.isPresent());
+        assertEquals(1, stagesModel.get().getStageModelList().size());
         StageModel stageModel = stagesModel.get().getStageModelList().get(0);
         Optional<StagesModel> innerStagesModel = stageModel.getStagesModel();
-        Assert.assertTrue(innerStagesModel.isPresent());
-        Assert.assertEquals(1, innerStagesModel.get().getStageModelList().size());
+        assertTrue(innerStagesModel.isPresent());
+        assertEquals(1, innerStagesModel.get().getStageModelList().size());
     }
 
     @Test
-    public void scenarioEnvironment() throws IOException {
+    void scenarioEnvironment() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/stages/stagesScenarioEnvironment.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<StagesModel> stagesModel = pipelineModel.get().getStages();
-        Assert.assertTrue(stagesModel.isPresent());
-        Assert.assertEquals(1, stagesModel.get().getStageModelList().size());
+        assertTrue(stagesModel.isPresent());
+        assertEquals(1, stagesModel.get().getStageModelList().size());
         StageModel stageModel = stagesModel.get().getStageModelList().get(0);
         Optional<EnvironmentModel> environmentModel = stageModel.getEnvironmentModel();
-        Assert.assertTrue(environmentModel.isPresent());
-        Assert.assertEquals(1, environmentModel.get().getEnvironmentVariables().size());
+        assertTrue(environmentModel.isPresent());
+        assertEquals(1, environmentModel.get().getEnvironmentVariables().size());
     }
 
     @Test
-    public void scenarioInput() throws IOException {
+    void scenarioInput() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/stages/stagesScenarioInput.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<StagesModel> stagesModel = pipelineModel.get().getStages();
-        Assert.assertTrue(stagesModel.isPresent());
-        Assert.assertEquals(1, stagesModel.get().getStageModelList().size());
+        assertTrue(stagesModel.isPresent());
+        assertEquals(1, stagesModel.get().getStageModelList().size());
         StageModel stageModel = stagesModel.get().getStageModelList().get(0);
         Optional<InputModel> inputModel = stageModel.getInputModel();
-        Assert.assertTrue(inputModel.isPresent());
-        Assert.assertEquals("message", inputModel.get().getMessage());
-        Assert.assertEquals("id", inputModel.get().getId().get());
-        Assert.assertEquals("ok", inputModel.get().getOk().get());
-        Assert.assertEquals("submitter", inputModel.get().getSubmitter().get());
-        Assert.assertEquals(
+        assertTrue(inputModel.isPresent());
+        assertEquals("message", inputModel.get().getMessage());
+        assertEquals("id", inputModel.get().getId().get());
+        assertEquals("ok", inputModel.get().getOk().get());
+        assertEquals("submitter", inputModel.get().getSubmitter().get());
+        assertEquals(
                 "submitterParameter", inputModel.get().getSubmitterParameter().get());
         Optional<ParametersModel> parametersModel = inputModel.get().getParametersModel();
-        Assert.assertTrue(parametersModel.isPresent());
-        Assert.assertEquals(1, parametersModel.get().getParametersList().size());
+        assertTrue(parametersModel.isPresent());
+        assertEquals(1, parametersModel.get().getParametersList().size());
     }
 }

--- a/src/test/java/io/jenkins/plugins/pipeline/StepsParserTest.java
+++ b/src/test/java/io/jenkins/plugins/pipeline/StepsParserTest.java
@@ -1,5 +1,8 @@
 package io.jenkins.plugins.pipeline;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import io.jenkins.plugins.pipeline.models.*;
 import io.jenkins.plugins.pipeline.parsers.PipelineParser;
 import java.io.File;
@@ -8,180 +11,171 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class StepsParserTest {
-
-    @Before
-    public void setup() {}
+class StepsParserTest {
 
     @Test
-    public void stepsScenario1() throws IOException {
+    void stepsScenario1() throws IOException {
         String jenkinsFileContent =
                 FileUtils.readFileToString(new File("src/test/resources/steps/stepsBasic.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<StagesModel> stages = pipelineModel.get().getStages();
-        Assert.assertTrue(stages.isPresent());
+        assertTrue(stages.isPresent());
         List<StageModel> stageModelList = stages.get().getStageModelList();
-        Assert.assertEquals(1, stageModelList.size());
+        assertEquals(1, stageModelList.size());
         Optional<StepsModel> stepsModel = stageModelList.get(0).getStepsModel();
-        Assert.assertTrue(stepsModel.isPresent());
-        Assert.assertEquals(1, stepsModel.get().getSteps().size());
+        assertTrue(stepsModel.isPresent());
+        assertEquals(1, stepsModel.get().getSteps().size());
     }
 
     @Test
-    public void stepsScenario2() throws IOException {
+    void stepsScenario2() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/steps/stepsBasicWithScript.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<StagesModel> stages = pipelineModel.get().getStages();
-        Assert.assertTrue(stages.isPresent());
+        assertTrue(stages.isPresent());
         List<StageModel> stageModelList = stages.get().getStageModelList();
-        Assert.assertEquals(1, stageModelList.size());
+        assertEquals(1, stageModelList.size());
         Optional<StepsModel> stepsModel = stageModelList.get(0).getStepsModel();
-        Assert.assertTrue(stepsModel.isPresent());
+        assertTrue(stepsModel.isPresent());
         Optional<ScriptModel> script = stepsModel.get().getScript();
-        Assert.assertTrue(script.isPresent());
-        Assert.assertEquals(1, script.get().getScripts().size());
+        assertTrue(script.isPresent());
+        assertEquals(1, script.get().getScripts().size());
     }
 
     @Test
-    public void stepsScenario3() throws IOException {
+    void stepsScenario3() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/steps/stepsScriptMultiline.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<StagesModel> stages = pipelineModel.get().getStages();
-        Assert.assertTrue(stages.isPresent());
+        assertTrue(stages.isPresent());
         List<StageModel> stageModelList = stages.get().getStageModelList();
-        Assert.assertEquals(1, stageModelList.size());
+        assertEquals(1, stageModelList.size());
         Optional<StepsModel> stepsModel = stageModelList.get(0).getStepsModel();
-        Assert.assertTrue(stepsModel.isPresent());
+        assertTrue(stepsModel.isPresent());
         Optional<ScriptModel> script = stepsModel.get().getScript();
-        Assert.assertTrue(script.isPresent());
-        Assert.assertEquals(3, script.get().getScripts().size());
+        assertTrue(script.isPresent());
+        assertEquals(3, script.get().getScripts().size());
     }
 
     @Test
-    public void stepsScenario4() throws IOException {
+    void stepsScenario4() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/steps/stepsMultiLine.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<StagesModel> stages = pipelineModel.get().getStages();
-        Assert.assertTrue(stages.isPresent());
+        assertTrue(stages.isPresent());
         List<StageModel> stageModelList = stages.get().getStageModelList();
-        Assert.assertEquals(1, stageModelList.size());
+        assertEquals(1, stageModelList.size());
         Optional<StepsModel> stepsModel = stageModelList.get(0).getStepsModel();
-        Assert.assertTrue(stepsModel.isPresent());
-        Assert.assertEquals(3, stepsModel.get().getSteps().size());
+        assertTrue(stepsModel.isPresent());
+        assertEquals(3, stepsModel.get().getSteps().size());
     }
 
     @Test
-    public void stepsScenario5() throws IOException {
+    void stepsScenario5() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/steps/stepsWithCredentialsAndEnv.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<StagesModel> stages = pipelineModel.get().getStages();
-        Assert.assertTrue(stages.isPresent());
+        assertTrue(stages.isPresent());
         List<StageModel> stageModelList = stages.get().getStageModelList();
-        Assert.assertEquals(1, stageModelList.size());
+        assertEquals(1, stageModelList.size());
         Optional<StepsModel> stepsModel = stageModelList.get(0).getStepsModel();
-        Assert.assertTrue(stepsModel.isPresent());
+        assertTrue(stepsModel.isPresent());
         Optional<ScriptModel> script = stepsModel.get().getScript();
-        Assert.assertTrue(script.isPresent());
-        Assert.assertEquals(4, script.get().getScripts().size());
+        assertTrue(script.isPresent());
+        assertEquals(4, script.get().getScripts().size());
         Optional<SubScriptModel> subScriptModel =
                 (Optional<SubScriptModel>) script.get().getScripts().get(0);
-        Assert.assertTrue(subScriptModel.isPresent());
-        Assert.assertEquals("withAnt", subScriptModel.get().getDirective());
-        Assert.assertEquals(
-                1, subScriptModel.get().getScriptModel().getScripts().size());
+        assertTrue(subScriptModel.isPresent());
+        assertEquals("withAnt", subScriptModel.get().getDirective());
+        assertEquals(1, subScriptModel.get().getScriptModel().getScripts().size());
         System.out.println(pipelineModel.get().toPrettyGroovy());
     }
 
     @Test
-    public void stepsScenario6() throws IOException {
+    void stepsScenario6() throws IOException {
         String jenkinsFileContent =
                 FileUtils.readFileToString(new File("src/test/resources/steps/stepsDir.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<StagesModel> stages = pipelineModel.get().getStages();
-        Assert.assertTrue(stages.isPresent());
+        assertTrue(stages.isPresent());
         List<StageModel> stageModelList = stages.get().getStageModelList();
-        Assert.assertEquals(1, stageModelList.size());
+        assertEquals(1, stageModelList.size());
         Optional<StepsModel> stepsModel = stageModelList.get(0).getStepsModel();
-        Assert.assertTrue(stepsModel.isPresent());
+        assertTrue(stepsModel.isPresent());
         Optional<ScriptModel> script = stepsModel.get().getScript();
-        Assert.assertTrue(script.isPresent());
-        Assert.assertEquals(2, script.get().getScripts().size());
+        assertTrue(script.isPresent());
+        assertEquals(2, script.get().getScripts().size());
         Optional<SubScriptModel> subScriptModel =
                 (Optional<SubScriptModel>) script.get().getScripts().get(1);
-        Assert.assertTrue(subScriptModel.isPresent());
-        Assert.assertEquals("dir", subScriptModel.get().getDirective());
-        Assert.assertEquals(
-                1, subScriptModel.get().getScriptModel().getScripts().size());
+        assertTrue(subScriptModel.isPresent());
+        assertEquals("dir", subScriptModel.get().getDirective());
+        assertEquals(1, subScriptModel.get().getScriptModel().getScripts().size());
         System.out.println(pipelineModel.get().toPrettyGroovy());
     }
 
     @Test
-    public void stepsScenario7() throws IOException {
+    void stepsScenario7() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/steps/stepsCatchError.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<StagesModel> stages = pipelineModel.get().getStages();
-        Assert.assertTrue(stages.isPresent());
+        assertTrue(stages.isPresent());
         List<StageModel> stageModelList = stages.get().getStageModelList();
-        Assert.assertEquals(1, stageModelList.size());
+        assertEquals(1, stageModelList.size());
         Optional<StepsModel> stepsModel = stageModelList.get(0).getStepsModel();
-        Assert.assertTrue(stepsModel.isPresent());
+        assertTrue(stepsModel.isPresent());
         Optional<ScriptModel> script = stepsModel.get().getScript();
-        Assert.assertTrue(script.isPresent());
-        Assert.assertEquals(1, script.get().getScripts().size());
+        assertTrue(script.isPresent());
+        assertEquals(1, script.get().getScripts().size());
         Optional<SubScriptModel> subScriptModel =
                 (Optional<SubScriptModel>) script.get().getScripts().get(0);
-        Assert.assertTrue(subScriptModel.isPresent());
-        Assert.assertEquals("catchError", subScriptModel.get().getDirective());
-        Assert.assertEquals(
-                1, subScriptModel.get().getScriptModel().getScripts().size());
+        assertTrue(subScriptModel.isPresent());
+        assertEquals("catchError", subScriptModel.get().getDirective());
+        assertEquals(1, subScriptModel.get().getScriptModel().getScripts().size());
         System.out.println(pipelineModel.get().toPrettyGroovy());
     }
 
     @Test
-    public void stepsScenario8() throws IOException {
+    void stepsScenario8() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/steps/stepsWithEnvAdvanced.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<StagesModel> stages = pipelineModel.get().getStages();
-        Assert.assertTrue(stages.isPresent());
+        assertTrue(stages.isPresent());
         List<StageModel> stageModelList = stages.get().getStageModelList();
-        Assert.assertEquals(1, stageModelList.size());
+        assertEquals(1, stageModelList.size());
         Optional<StepsModel> stepsModel = stageModelList.get(0).getStepsModel();
-        Assert.assertTrue(stepsModel.isPresent());
+        assertTrue(stepsModel.isPresent());
         Optional<ScriptModel> script = stepsModel.get().getScript();
-        Assert.assertTrue(script.isPresent());
-        Assert.assertEquals(1, script.get().getScripts().size());
+        assertTrue(script.isPresent());
+        assertEquals(1, script.get().getScripts().size());
         Optional<SubScriptModel> subScriptModel =
                 (Optional<SubScriptModel>) script.get().getScripts().get(0);
-        Assert.assertTrue(subScriptModel.isPresent());
-        Assert.assertEquals("withEnv", subScriptModel.get().getDirective());
-        Assert.assertEquals(
-                2, subScriptModel.get().getScriptModel().getScripts().size());
+        assertTrue(subScriptModel.isPresent());
+        assertEquals("withEnv", subScriptModel.get().getDirective());
+        assertEquals(2, subScriptModel.get().getScriptModel().getScripts().size());
         System.out.println(pipelineModel.get().toPrettyGroovy());
     }
 }

--- a/src/test/java/io/jenkins/plugins/pipeline/ToolsParserTest.java
+++ b/src/test/java/io/jenkins/plugins/pipeline/ToolsParserTest.java
@@ -1,5 +1,8 @@
 package io.jenkins.plugins.pipeline;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import io.jenkins.plugins.pipeline.models.ChildToolModel;
 import io.jenkins.plugins.pipeline.models.PipelineModel;
 import io.jenkins.plugins.pipeline.models.ToolsModel;
@@ -9,43 +12,38 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ToolsParserTest {
-
-    @Before
-    public void setup() {}
+class ToolsParserTest {
 
     @Test
-    public void toolsSingle() throws IOException {
+    void toolsSingle() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/tools/toolsSingle.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<ToolsModel> toolsModel = pipelineModel.get().getTools();
-        Assert.assertTrue(toolsModel.isPresent());
-        Assert.assertEquals(1, toolsModel.get().getChildToolModels().size());
+        assertTrue(toolsModel.isPresent());
+        assertEquals(1, toolsModel.get().getChildToolModels().size());
         for (ChildToolModel childToolModel : toolsModel.get().getChildToolModels()) {
-            Assert.assertEquals("maven", childToolModel.getToolName());
-            Assert.assertEquals("maven", childToolModel.getToolType());
+            assertEquals("maven", childToolModel.getToolName());
+            assertEquals("maven", childToolModel.getToolType());
         }
     }
 
     @Test
-    public void toolsMulti() throws IOException {
+    void toolsMulti() throws IOException {
         String jenkinsFileContent =
                 FileUtils.readFileToString(new File("src/test/resources/tools/toolsMulti.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<ToolsModel> toolsModel = pipelineModel.get().getTools();
-        Assert.assertTrue(toolsModel.isPresent());
-        Assert.assertEquals(2, toolsModel.get().getChildToolModels().size());
+        assertTrue(toolsModel.isPresent());
+        assertEquals(2, toolsModel.get().getChildToolModels().size());
         for (ChildToolModel childToolModel : toolsModel.get().getChildToolModels()) {
-            Assert.assertEquals(childToolModel.getToolType(), childToolModel.getToolName());
+            assertEquals(childToolModel.getToolType(), childToolModel.getToolName());
         }
     }
 }

--- a/src/test/java/io/jenkins/plugins/pipeline/TriggersParserTest.java
+++ b/src/test/java/io/jenkins/plugins/pipeline/TriggersParserTest.java
@@ -1,5 +1,8 @@
 package io.jenkins.plugins.pipeline;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import io.jenkins.plugins.pipeline.models.PipelineModel;
 import io.jenkins.plugins.pipeline.models.TriggersModel;
 import io.jenkins.plugins.pipeline.parsers.PipelineParser;
@@ -8,36 +11,31 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class TriggersParserTest {
-
-    @Before
-    public void setup() {}
+class TriggersParserTest {
 
     @Test
-    public void triggersSingleTest() throws IOException {
+    void triggersSingleTest() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/triggers/triggersSingle.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<TriggersModel> triggersModel = pipelineModel.get().getTriggers();
-        Assert.assertTrue(triggersModel.isPresent());
-        Assert.assertEquals(1, triggersModel.get().getTriggersList().size());
+        assertTrue(triggersModel.isPresent());
+        assertEquals(1, triggersModel.get().getTriggersList().size());
     }
 
     @Test
-    public void triggersMultiTest() throws IOException {
+    void triggersMultiTest() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/triggers/triggersMulti.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<TriggersModel> triggersModel = pipelineModel.get().getTriggers();
-        Assert.assertTrue(triggersModel.isPresent());
-        Assert.assertEquals(2, triggersModel.get().getTriggersList().size());
+        assertTrue(triggersModel.isPresent());
+        assertEquals(2, triggersModel.get().getTriggersList().size());
     }
 }

--- a/src/test/java/io/jenkins/plugins/pipeline/WhenParserTest.java
+++ b/src/test/java/io/jenkins/plugins/pipeline/WhenParserTest.java
@@ -1,5 +1,8 @@
 package io.jenkins.plugins.pipeline;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import io.jenkins.plugins.pipeline.models.*;
 import io.jenkins.plugins.pipeline.parsers.PipelineParser;
 import java.io.File;
@@ -8,87 +11,82 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class WhenParserTest {
-
-    @Before
-    public void setup() {}
+class WhenParserTest {
 
     @Test
-    public void whenScenario1() throws IOException {
+    void whenScenario1() throws IOException {
         String jenkinsFileContent =
                 FileUtils.readFileToString(new File("src/test/resources/when/whenBasic.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<StagesModel> stages = pipelineModel.get().getStages();
-        Assert.assertTrue(stages.isPresent());
+        assertTrue(stages.isPresent());
         List<StageModel> stageModelList = stages.get().getStageModelList();
-        Assert.assertEquals(1, stageModelList.size());
+        assertEquals(1, stageModelList.size());
         Optional<WhenModel> whenModel = stageModelList.get(0).getWhenModel();
-        Assert.assertTrue(whenModel.isPresent());
+        assertTrue(whenModel.isPresent());
         List<String> whenRuleList = whenModel.get().getWhenRuleList();
-        Assert.assertEquals(1, whenRuleList.size());
+        assertEquals(1, whenRuleList.size());
     }
 
     @Test
-    public void whenScenario2() throws IOException {
+    void whenScenario2() throws IOException {
         String jenkinsFileContent =
                 FileUtils.readFileToString(new File("src/test/resources/when/whenAnyOf.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<StagesModel> stages = pipelineModel.get().getStages();
-        Assert.assertTrue(stages.isPresent());
+        assertTrue(stages.isPresent());
         List<StageModel> stageModelList = stages.get().getStageModelList();
-        Assert.assertEquals(1, stageModelList.size());
+        assertEquals(1, stageModelList.size());
         Optional<WhenModel> whenModel = stageModelList.get(0).getWhenModel();
-        Assert.assertTrue(whenModel.isPresent());
+        assertTrue(whenModel.isPresent());
         Optional<WhenConditionModel> whenConditionModel = whenModel.get().getWhenConditionModel();
-        Assert.assertTrue(whenConditionModel.isPresent());
+        assertTrue(whenConditionModel.isPresent());
         List<String> whenRuleList = whenConditionModel.get().getWhenRuleList();
-        Assert.assertEquals(2, whenRuleList.size());
+        assertEquals(2, whenRuleList.size());
     }
 
     @Test
-    public void whenScenario3() throws IOException {
+    void whenScenario3() throws IOException {
         String jenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/when/whenInnerConditions.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<StagesModel> stages = pipelineModel.get().getStages();
-        Assert.assertTrue(stages.isPresent());
+        assertTrue(stages.isPresent());
         List<StageModel> stageModelList = stages.get().getStageModelList();
-        Assert.assertEquals(1, stageModelList.size());
+        assertEquals(1, stageModelList.size());
         Optional<WhenModel> whenModel = stageModelList.get(0).getWhenModel();
-        Assert.assertTrue(whenModel.isPresent());
+        assertTrue(whenModel.isPresent());
         Optional<WhenConditionModel> whenConditionModel = whenModel.get().getWhenConditionModel();
-        Assert.assertTrue(whenConditionModel.isPresent());
+        assertTrue(whenConditionModel.isPresent());
         Optional<WhenConditionModel> innerWhenConditionModel =
                 whenConditionModel.get().getWhenConditionModel();
-        Assert.assertTrue(innerWhenConditionModel.isPresent());
+        assertTrue(innerWhenConditionModel.isPresent());
         List<String> whenRuleList = innerWhenConditionModel.get().getWhenRuleList();
-        Assert.assertEquals(2, whenRuleList.size());
+        assertEquals(2, whenRuleList.size());
     }
 
     @Test
-    public void whenScenario4() throws IOException {
+    void whenScenario4() throws IOException {
         String jenkinsFileContent =
                 FileUtils.readFileToString(new File("src/test/resources/when/whenFlags.yml"), StandardCharsets.UTF_8);
         PipelineParser pipelineParser = new PipelineParser(jenkinsFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parse();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         Optional<StagesModel> stages = pipelineModel.get().getStages();
-        Assert.assertTrue(stages.isPresent());
+        assertTrue(stages.isPresent());
         List<StageModel> stageModelList = stages.get().getStageModelList();
-        Assert.assertEquals(1, stageModelList.size());
+        assertEquals(1, stageModelList.size());
         Optional<WhenModel> whenModel = stageModelList.get(0).getWhenModel();
-        Assert.assertTrue(whenModel.isPresent());
-        Assert.assertEquals(1, whenModel.get().getWhenRuleList().size());
-        Assert.assertTrue(whenModel.get().getBeforeAgent().get());
+        assertTrue(whenModel.isPresent());
+        assertEquals(1, whenModel.get().getWhenRuleList().size());
+        assertTrue(whenModel.get().getBeforeAgent().get());
     }
 }


### PR DESCRIPTION
This PR aims to migrate all tests to JUnit5. Changes include:

* Migrate annotations and imports
* Migrate assertions
* Remove public visibility for test classes and methods
* Minor clean up

There are four exceptions where a migration was not possible as the tests rely on `Rule` implementations that have not (yet) been migrated to JUnit5:

* `PipelineAsYamlScmFlowDefinitionTest` using `GitSampleRepoRule`
* `PipelineAsYamlScriptFlowDefinitionTest` using `GitSampleRepoRule`
* `PipelineAsYamlWorkflowBranchProjectFactoryTest` using `GitSampleRepoRule`
* `PipelineParserTest` using `GitSampleRepoRule`

I am well aware that this is a quite large changeset however I hope that there is still interest in this PR and it will be reviewed.
If there are any questions, please do not hesitate to ping me.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub 
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
