### PR TITLE
Migrate GitSampleRepoRule to JUnit5

### DIFF
--- a/src/test/java/io/jenkins/plugins/pipeline/PipelineAsYamlScmFlowDefinitionTest.java
+++ b/src/test/java/io/jenkins/plugins/pipeline/PipelineAsYamlScmFlowDefinitionTest.java
@@ -1,5 +1,8 @@
 package io.jenkins.plugins.pipeline;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import hudson.model.Result;
 import hudson.plugins.git.GitSCM;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
@@ -7,6 +10,7 @@ import java.util.List;
 import java.util.UUID;
 import jenkins.plugins.git.GitSCMSource;
 import jenkins.plugins.git.GitSampleRepoRule;
+import jenkins.plugins.git.junit.jupiter.WithGitSampleRepo;
 import jenkins.plugins.git.traits.BranchDiscoveryTrait;
 import jenkins.scm.impl.trait.WildcardSCMHeadFilterTrait;
 import org.apache.commons.io.FileUtils;
@@ -15,54 +19,54 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.libs.GlobalLibraries;
 import org.jenkinsci.plugins.workflow.libs.LibraryConfiguration;
 import org.jenkinsci.plugins.workflow.libs.SCMSourceRetriever;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class PipelineAsYamlScmFlowDefinitionTest {
+@WithJenkins
+@WithGitSampleRepo
+class PipelineAsYamlScmFlowDefinitionTest {
 
-    @Rule
-    public JenkinsRule jenkinsRule = new JenkinsRule();
+    private JenkinsRule jenkinsRule;
+    private GitSampleRepoRule gitRepo;
+    private final String yamlJenkinsFileName = "Jenkinsfile.yaml";
 
-    @Rule
-    public GitSampleRepoRule sourceCodeRepo = new GitSampleRepoRule();
-
-    @Rule
-    public GitSampleRepoRule libraryCodeRepo = new GitSampleRepoRule();
-
-    private String yamlJenkinsFileName = "Jenkinsfile.yaml";
-    private String[] scmBranches = {"feature", "hotfix"};
+    @BeforeEach
+    void setUp(JenkinsRule jenkinsRule, GitSampleRepoRule gitRepo) {
+        this.jenkinsRule = jenkinsRule;
+        this.gitRepo = gitRepo;
+    }
 
     @Test
-    public void testAllInOne() throws Exception {
+    void testAllInOne() throws Exception {
         String yamlJenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/job/pipelineAllInOne.yml"), StandardCharsets.UTF_8);
-        this.sourceCodeRepo.init();
-        this.sourceCodeRepo.write(this.yamlJenkinsFileName, yamlJenkinsFileContent);
-        this.sourceCodeRepo.git("add", this.yamlJenkinsFileName);
-        this.sourceCodeRepo.git("commit", "--all", "--message=InitRepoWithFile");
+        this.gitRepo.init();
+        this.gitRepo.write(this.yamlJenkinsFileName, yamlJenkinsFileContent);
+        this.gitRepo.git("add", this.yamlJenkinsFileName);
+        this.gitRepo.git("commit", "--all", "--message=InitRepoWithFile");
         WorkflowJob workflowJob = this.jenkinsRule.createProject(
                 WorkflowJob.class, UUID.randomUUID().toString());
         workflowJob.setDefinition(new PipelineAsYamlScmFlowDefinition(
-                this.yamlJenkinsFileName, new GitSCM(this.sourceCodeRepo.toString()), false));
+                this.yamlJenkinsFileName, new GitSCM(this.gitRepo.toString()), false));
         workflowJob.scheduleBuild2(0);
         jenkinsRule.waitUntilNoActivity();
         WorkflowRun workflowRun = workflowJob.getLastBuild();
         System.out.println(workflowRun.getLog());
-        Assert.assertEquals("SUCCESS", workflowRun.getResult().toString());
+        assertEquals(Result.SUCCESS, workflowRun.getResult());
     }
 
     @Test
-    public void testWithLibrary() throws Exception {
+    void testWithLibrary() throws Exception {
 
-        this.libraryCodeRepo.init();
-        this.libraryCodeRepo.mkdirs("vars");
-        this.libraryCodeRepo.write("vars/customSteps.groovy", "def customStep(message)  {  echo \"${message}\" }");
-        this.libraryCodeRepo.git("add", "vars/customSteps.groovy");
-        this.libraryCodeRepo.git("commit", "--all", "--message=InitRepoWithStep");
+        this.gitRepo.init();
+        this.gitRepo.mkdirs("vars");
+        this.gitRepo.write("vars/customSteps.groovy", "def customStep(message)  {  echo \"${message}\" }");
+        this.gitRepo.git("add", "vars/customSteps.groovy");
+        this.gitRepo.git("commit", "--all", "--message=InitRepoWithStep");
 
-        GitSCMSource source = new GitSCMSource(this.libraryCodeRepo.toString());
+        GitSCMSource source = new GitSCMSource(this.gitRepo.toString());
         source.setTraits(List.of(new BranchDiscoveryTrait(), new WildcardSCMHeadFilterTrait("*", "")));
         LibraryConfiguration sharedLibraryConfiguration =
                 new LibraryConfiguration("customSharedLibrary", new SCMSourceRetriever(source));
@@ -72,19 +76,18 @@ public class PipelineAsYamlScmFlowDefinitionTest {
 
         String yamlJenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/job/pipelineTestWithLibrary.yml"), StandardCharsets.UTF_8);
-        this.sourceCodeRepo.init();
-        this.sourceCodeRepo.write(this.yamlJenkinsFileName, yamlJenkinsFileContent);
-        this.sourceCodeRepo.git("add", this.yamlJenkinsFileName);
-        this.sourceCodeRepo.git("commit", "--all", "--message=InitRepoWithFile");
+        this.gitRepo.write(this.yamlJenkinsFileName, yamlJenkinsFileContent);
+        this.gitRepo.git("add", this.yamlJenkinsFileName);
+        this.gitRepo.git("commit", "--all", "--message=InitRepoWithFile");
         WorkflowJob workflowJob = this.jenkinsRule.createProject(
                 WorkflowJob.class, UUID.randomUUID().toString());
         workflowJob.setDefinition(new PipelineAsYamlScmFlowDefinition(
-                this.yamlJenkinsFileName, new GitSCM(this.sourceCodeRepo.toString()), false));
+                this.yamlJenkinsFileName, new GitSCM(this.gitRepo.toString()), false));
         workflowJob.scheduleBuild2(0);
         jenkinsRule.waitUntilNoActivity();
         WorkflowRun workflowRun = workflowJob.getLastBuild();
         System.out.println(workflowRun.getLog());
         this.jenkinsRule.assertLogContains("customEcho", workflowRun);
-        Assert.assertEquals("SUCCESS", workflowRun.getResult().toString());
+        assertEquals(Result.SUCCESS, workflowRun.getResult());
     }
 }

--- a/src/test/java/io/jenkins/plugins/pipeline/PipelineAsYamlWorkflowBranchProjectFactoryTest.java
+++ b/src/test/java/io/jenkins/plugins/pipeline/PipelineAsYamlWorkflowBranchProjectFactoryTest.java
@@ -1,5 +1,8 @@
 package io.jenkins.plugins.pipeline;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import hudson.model.Result;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
@@ -8,6 +11,7 @@ import java.util.UUID;
 import jenkins.branch.BranchSource;
 import jenkins.plugins.git.GitSCMSource;
 import jenkins.plugins.git.GitSampleRepoRule;
+import jenkins.plugins.git.junit.jupiter.WithGitSampleRepo;
 import jenkins.plugins.git.traits.BranchDiscoveryTrait;
 import jenkins.scm.impl.trait.WildcardSCMHeadFilterTrait;
 import org.apache.commons.io.FileUtils;
@@ -17,39 +21,41 @@ import org.jenkinsci.plugins.workflow.libs.GlobalLibraries;
 import org.jenkinsci.plugins.workflow.libs.LibraryConfiguration;
 import org.jenkinsci.plugins.workflow.libs.SCMSourceRetriever;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class PipelineAsYamlWorkflowBranchProjectFactoryTest {
+@WithJenkins
+@WithGitSampleRepo
+class PipelineAsYamlWorkflowBranchProjectFactoryTest {
 
-    @Rule
-    public JenkinsRule jenkins = new JenkinsRule();
+    private JenkinsRule jenkins;
+    private GitSampleRepoRule gitRepo;
 
-    @Rule
-    public GitSampleRepoRule sourceCodeRepo = new GitSampleRepoRule();
+    private final String yamlJenkinsFileName = "yamlJenkinsfile.yaml";
+    private final String[] scmBranches = {"feature", "hotfix"};
 
-    @Rule
-    public GitSampleRepoRule libraryCodeRepo = new GitSampleRepoRule();
-
-    private String yamlJenkinsFileName = "yamlJenkinsfile.yaml";
-    private String[] scmBranches = {"feature", "hotfix"};
+    @BeforeEach
+    void setUp(JenkinsRule jenkinsRule, GitSampleRepoRule sourceCodeRepo) {
+        this.jenkins = jenkinsRule;
+        this.gitRepo = sourceCodeRepo;
+    }
 
     @Test
-    public void testWithBranches() throws Exception {
+    void testWithBranches() throws Exception {
         String yamlJenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/job/pipelineTestWithBranches.yml"), StandardCharsets.UTF_8);
-        this.sourceCodeRepo.init();
-        this.sourceCodeRepo.write(this.yamlJenkinsFileName, yamlJenkinsFileContent);
-        this.sourceCodeRepo.git("add", this.yamlJenkinsFileName);
-        this.sourceCodeRepo.git("commit", "--all", "--message=InitRepoWithFile");
+        this.gitRepo.init();
+        this.gitRepo.write(this.yamlJenkinsFileName, yamlJenkinsFileContent);
+        this.gitRepo.git("add", this.yamlJenkinsFileName);
+        this.gitRepo.git("commit", "--all", "--message=InitRepoWithFile");
         for (String branch : this.scmBranches) {
-            this.sourceCodeRepo.git("checkout", "-b", branch, "master");
+            this.gitRepo.git("checkout", "-b", branch, "master");
         }
         WorkflowMultiBranchProject workflowMultiBranchProject = this.jenkins.createProject(
                 WorkflowMultiBranchProject.class, UUID.randomUUID().toString());
-        GitSCMSource sourceCodeRepoSCMSource = new GitSCMSource(this.sourceCodeRepo.toString());
+        GitSCMSource sourceCodeRepoSCMSource = new GitSCMSource(this.gitRepo.toString());
         sourceCodeRepoSCMSource.setTraits(List.of(new BranchDiscoveryTrait(), new WildcardSCMHeadFilterTrait("*", "")));
         workflowMultiBranchProject.getSourcesList().add(new BranchSource(sourceCodeRepoSCMSource));
         PipelineAsYamlWorkflowBranchProjectFactory pipelineAsYamlWorkflowBranchProjectFactory =
@@ -58,25 +64,25 @@ public class PipelineAsYamlWorkflowBranchProjectFactoryTest {
         workflowMultiBranchProject.scheduleBuild2(0);
         this.jenkins.waitUntilNoActivity();
         Collection<WorkflowJob> items = workflowMultiBranchProject.getItems();
-        Assert.assertEquals(this.scmBranches.length + 1, items.size());
+        assertEquals(this.scmBranches.length + 1, items.size());
         for (WorkflowJob job : items) {
             WorkflowRun run = job.getLastBuild();
-            String testString = "test-output-" + job.getName();
+            assertEquals(Result.SUCCESS, run.getResult());
             System.out.println(run.getLog());
         }
     }
 
     @Test
-    public void testAllInOne() throws Exception {
+    void testAllInOne() throws Exception {
         String yamlJenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/job/pipelineAllInOne.yml"), StandardCharsets.UTF_8);
-        this.sourceCodeRepo.init();
-        this.sourceCodeRepo.write(this.yamlJenkinsFileName, yamlJenkinsFileContent);
-        this.sourceCodeRepo.git("add", this.yamlJenkinsFileName);
-        this.sourceCodeRepo.git("commit", "--all", "--message=InitRepoWithFile");
+        this.gitRepo.init();
+        this.gitRepo.write(this.yamlJenkinsFileName, yamlJenkinsFileContent);
+        this.gitRepo.git("add", this.yamlJenkinsFileName);
+        this.gitRepo.git("commit", "--all", "--message=InitRepoWithFile");
         WorkflowMultiBranchProject workflowMultiBranchProject = this.jenkins.createProject(
                 WorkflowMultiBranchProject.class, UUID.randomUUID().toString());
-        GitSCMSource sourceCodeRepoSCMSource = new GitSCMSource(this.sourceCodeRepo.toString());
+        GitSCMSource sourceCodeRepoSCMSource = new GitSCMSource(this.gitRepo.toString());
         sourceCodeRepoSCMSource.setTraits(List.of(new BranchDiscoveryTrait(), new WildcardSCMHeadFilterTrait("*", "")));
         workflowMultiBranchProject.getSourcesList().add(new BranchSource(sourceCodeRepoSCMSource));
         PipelineAsYamlWorkflowBranchProjectFactory pipelineAsYamlWorkflowBranchProjectFactory =
@@ -87,27 +93,26 @@ public class PipelineAsYamlWorkflowBranchProjectFactoryTest {
         Collection<WorkflowJob> items = workflowMultiBranchProject.getItems();
         for (WorkflowJob job : items) {
             WorkflowRun run = job.getLastBuild();
-            Assert.assertEquals("SUCCESS", run.getResult().toString());
+            assertEquals(Result.SUCCESS, run.getResult());
             System.out.println(run.getLog());
         }
     }
 
     @Test
-    public void testWithSharedLibrary() throws Exception {
+    void testWithSharedLibrary() throws Exception {
         String yamlJenkinsFileContent = FileUtils.readFileToString(
                 new File("src/test/resources/job/pipelineTestWithLibrary.yml"), StandardCharsets.UTF_8);
-        this.sourceCodeRepo.init();
-        this.sourceCodeRepo.write(this.yamlJenkinsFileName, yamlJenkinsFileContent);
-        this.sourceCodeRepo.git("add", this.yamlJenkinsFileName);
-        this.sourceCodeRepo.git("commit", "--all", "--message=InitRepoWithFile");
+        this.gitRepo.init();
+        this.gitRepo.write(this.yamlJenkinsFileName, yamlJenkinsFileContent);
+        this.gitRepo.git("add", this.yamlJenkinsFileName);
+        this.gitRepo.git("commit", "--all", "--message=InitRepoWithFile");
 
-        this.libraryCodeRepo.init();
-        this.libraryCodeRepo.mkdirs("vars");
-        this.libraryCodeRepo.write("vars/customSteps.groovy", "def customStep(message)  {  echo \"${message}\" }");
-        this.libraryCodeRepo.git("add", "vars/customSteps.groovy");
-        this.libraryCodeRepo.git("commit", "--all", "--message=InitRepoWithStep");
+        this.gitRepo.mkdirs("vars");
+        this.gitRepo.write("vars/customSteps.groovy", "def customStep(message)  {  echo \"${message}\" }");
+        this.gitRepo.git("add", "vars/customSteps.groovy");
+        this.gitRepo.git("commit", "--all", "--message=InitRepoWithStep");
 
-        GitSCMSource source = new GitSCMSource(this.libraryCodeRepo.toString());
+        GitSCMSource source = new GitSCMSource(this.gitRepo.toString());
         source.setTraits(List.of(new BranchDiscoveryTrait(), new WildcardSCMHeadFilterTrait("*", "")));
         LibraryConfiguration sharedLibraryConfiguration =
                 new LibraryConfiguration("customSharedLibrary", new SCMSourceRetriever(source));
@@ -117,7 +122,7 @@ public class PipelineAsYamlWorkflowBranchProjectFactoryTest {
 
         WorkflowMultiBranchProject workflowMultiBranchProject = this.jenkins.createProject(
                 WorkflowMultiBranchProject.class, UUID.randomUUID().toString());
-        GitSCMSource sourceCodeRepoSCMSource = new GitSCMSource(this.libraryCodeRepo.toString());
+        GitSCMSource sourceCodeRepoSCMSource = new GitSCMSource(this.gitRepo.toString());
         sourceCodeRepoSCMSource.setTraits(List.of(new BranchDiscoveryTrait(), new WildcardSCMHeadFilterTrait("*", "")));
         workflowMultiBranchProject.getSourcesList().add(new BranchSource(sourceCodeRepoSCMSource));
         PipelineAsYamlWorkflowBranchProjectFactory pipelineAsYamlWorkflowBranchProjectFactory =
@@ -129,7 +134,7 @@ public class PipelineAsYamlWorkflowBranchProjectFactoryTest {
         for (WorkflowJob job : items) {
             WorkflowRun run = job.getLastBuild();
             this.jenkins.assertLogContains("customEcho", run);
-            Assert.assertEquals("SUCCESS", run.getResult().toString());
+            assertEquals(Result.SUCCESS, run.getResult());
         }
     }
 }

--- a/src/test/java/io/jenkins/plugins/pipeline/PipelineParserTest.java
+++ b/src/test/java/io/jenkins/plugins/pipeline/PipelineParserTest.java
@@ -1,5 +1,8 @@
 package io.jenkins.plugins.pipeline;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.CredentialsStore;
@@ -7,7 +10,6 @@ import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import hudson.ExtensionList;
-import hudson.model.Descriptor;
 import hudson.model.Result;
 import hudson.plugins.git.GitSCM;
 import io.jenkins.plugins.pipeline.models.PipelineModel;
@@ -21,58 +23,49 @@ import java.util.UUID;
 import jenkins.branch.BranchSource;
 import jenkins.plugins.git.GitSCMSource;
 import jenkins.plugins.git.GitSampleRepoRule;
+import jenkins.plugins.git.junit.jupiter.WithGitSampleRepo;
 import jenkins.plugins.git.traits.BranchDiscoveryTrait;
 import jenkins.scm.impl.trait.WildcardSCMHeadFilterTrait;
 import org.apache.commons.io.FileUtils;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-@RunWith(Parameterized.class)
-public class PipelineParserTest {
+@WithJenkins
+@WithGitSampleRepo
+class PipelineParserTest {
 
-    @Rule
-    public JenkinsRule jenkins = new JenkinsRule();
-
-    @Rule
-    public GitSampleRepoRule gitRepo = new GitSampleRepoRule();
+    private JenkinsRule jenkins;
+    private GitSampleRepoRule gitRepo;
 
     private SystemCredentialsProvider.ProviderImpl system;
     private CredentialsStore systemStore;
-    private String pipelineFile = "Jenkinsfile";
+    private final String pipelineFile = "Jenkinsfile";
     private String pipelineAsYamlFileContent;
 
-    @Parameterized.Parameters
-    public static Iterable<String> data() {
-        return List.of("src/test/resources/pipeline/pipelineAllinOne.yml");
-    }
-
-    @Before
-    public void setup() throws IOException, Descriptor.FormException {
+    @BeforeEach
+    void setUp(JenkinsRule jenkinsRule, GitSampleRepoRule gitRepo) throws Exception {
+        this.jenkins = jenkinsRule;
+        this.gitRepo = gitRepo;
         system = ExtensionList.lookup(CredentialsProvider.class).get(SystemCredentialsProvider.ProviderImpl.class);
         systemStore = system.getStore(jenkins.getInstance());
         systemStore.addCredentials(
                 Domain.global(),
                 new UsernamePasswordCredentialsImpl(
                         CredentialsScope.GLOBAL, "test-credentials", "", "username", "password"));
-    }
-
-    public PipelineParserTest(String filePath) throws IOException {
-        this.pipelineAsYamlFileContent = FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8);
+        pipelineAsYamlFileContent = FileUtils.readFileToString(
+                new File("src/test/resources/pipeline/pipelineAllinOne.yml"), StandardCharsets.UTF_8);
     }
 
     @Test
-    public void pipeline1() throws Exception {
+    void pipeline1() throws Exception {
         PipelineParser pipelineParser = new PipelineParser(this.pipelineAsYamlFileContent);
         Optional<PipelineModel> pipelineModel = pipelineParser.parseAndValidate();
-        Assert.assertTrue(pipelineModel.isPresent());
+        assertTrue(pipelineModel.isPresent());
         String prettyGroovyScript = pipelineModel.get().toPrettyGroovy();
         System.out.println(prettyGroovyScript);
         WorkflowMultiBranchProject workflowMultiBranchProject =
@@ -81,15 +74,14 @@ public class PipelineParserTest {
     }
 
     @Test
-    public void pipelineTestWithScm() throws Exception {
+    void pipelineTestWithScm() throws Exception {
         this.initSourceCodeRepo(this.pipelineAsYamlFileContent);
         WorkflowJob workflowJob = this.jenkins.createProject(WorkflowJob.class);
         workflowJob.setDefinition(new PipelineAsYamlScmFlowDefinition(
                 this.pipelineFile, new GitSCM(this.gitRepo.getRoot().getAbsolutePath()), false));
         workflowJob.scheduleBuild2(0);
         this.jenkins.waitUntilNoActivity();
-        Assert.assertEquals(
-                "SUCCESS", workflowJob.getBuilds().getLastBuild().getResult().toString());
+        assertEquals(Result.SUCCESS, workflowJob.getBuilds().getLastBuild().getResult());
     }
 
     private WorkflowMultiBranchProject createWorkflowMultiBranchPipelineJob(String pipelineScript) throws Exception {
@@ -101,7 +93,7 @@ public class PipelineParserTest {
         workflowMultiBranchProject.getSourcesList().add(new BranchSource(source));
         workflowMultiBranchProject.scheduleBuild2(0);
         this.jenkins.waitUntilNoActivity();
-        Assert.assertEquals(1, workflowMultiBranchProject.getItems().size());
+        assertEquals(1, workflowMultiBranchProject.getItems().size());
         return workflowMultiBranchProject;
     }
 
@@ -117,6 +109,6 @@ public class PipelineParserTest {
         WorkflowRun run = workflowJob.getLastBuild();
         System.out.println(run.getLog());
         Result result = run.getResult();
-        Assert.assertEquals("SUCCESS", result.toString());
+        assertEquals(Result.SUCCESS, result);
     }
 }


### PR DESCRIPTION
In #127 I said that some tests could not be migrated to JUnit5 as they are using `GitSampleRepoRule`. Turns out I was wrong about that and thanks to https://github.com/jenkinsci/git-plugin/pull/1574 they can be made compatible with JUnit5 as well.

### Testing done

`mvn clean verify`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
